### PR TITLE
implemented loadable config

### DIFF
--- a/parsing/stanza_parser.py
+++ b/parsing/stanza_parser.py
@@ -3,6 +3,8 @@ import stanza
 from stanza.utils.conll import CoNLL
 from parsing.clean_text import preparetext
 import os
+import json
+from pathlib import Path
 """
 
 This program is free software; you can redistribute it and/or
@@ -21,7 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 """
 
 #This function prepares the NLP pipeline
-def preparenlpconf(model,pipeline):
+def preparenlpconf(model, pipeline):
     #Build a simple config
     config= {'lang':model,'processors':pipeline}
     if model == "sq": 
@@ -46,6 +48,10 @@ def preparenlpconf(model,pipeline):
                         })
     return config
 
+def load_config(infile: Path):
+    with open(infile, encoding="utf-8") as fin:
+        config = json.load(fin)
+    return config
 
 #This functions is dedicated to the parsing of CIEP+...
 def parseciep(nlp,text,filename,target,miniciep):

--- a/ud-stanza-ciep.py
+++ b/ud-stanza-ciep.py
@@ -14,6 +14,7 @@ import stanza
 
 from parsing.stanza_parser import (
     preparenlpconf,
+    load_config
     parseciep
 )
 
@@ -100,7 +101,8 @@ def main():
 			            'pos_charlm_forward_path':"/stanza_resources/ja/forward_charlm/conll17.pt",
 			            'pos_charlm_backward_path':"/stanza_resources/ja/backward_charlm/conll17.pt",
                         }
-        
+    elif isinstance(args.config, str):     # We expect this to be a path to a JSON file
+        config = load_config(args.config)
     print(config)
     nlp = stanza.Pipeline(**config, logging_level="DEBUG",allow_unknown_language=True,use_gpu=gpu)
     for filename in sorted(glob.glob(args.source+'/*.txt')):


### PR DESCRIPTION
Implemented loadable config

When calling stanza-ciep.py, you can now supply a path to a json file with the config for the stanza parser.

Example of call:

`python stanza-ciep.py \
 --source path/to/source \
--target path/to/target \
--metadata path/to/metadata \
--miniciep True\
--config path/to/config`